### PR TITLE
Feature/Color scheme for DetailsModal status and action fields

### DIFF
--- a/ui/modal-details.go
+++ b/ui/modal-details.go
@@ -17,14 +17,33 @@ func DetailsModal(app *tview.Application, frame *tview.Frame, table *tview.Table
 		namespace := strings.TrimSpace(parts[4])
 		message := strings.TrimSpace(parts[5])
 
+		defaultStatusColour := "[white]"
+		switch status {
+		case "Warning":
+			defaultStatusColour = "[yellow]"
+		}
+
+		defaultActionColour := "[white]"
+		switch action {
+		case "Created", "SuccessfulCreate", "Completed":
+			defaultActionColour = "[green]"
+		case "Started", "Pulled", "Pulling":
+			defaultActionColour = "[blue]"
+		case "Killing", "BackOff", "Unhealthy", "FailedToRetrieveImagePullSecret":
+			defaultActionColour = "[red]"
+		}
+
 		detail := fmt.Sprintf(
 			"[blue]Time:      [white]%s\n"+
 				"[blue]Resource:  [white]%s\n"+
 				"[blue]Namespace: [white]%s\n"+
-				"[blue]Status:    [white]%s\n"+
-				"[blue]Action:    [white]%s\n"+
+				"[blue]Status:    %s%s\n"+
+				"[blue]Action:    %s%s\n"+
 				"[blue]Message:   [white]%s\n",
-			timeStr, resource, namespace, status, action, message,
+			timeStr, resource, namespace,
+			defaultStatusColour, status,
+			defaultActionColour, action,
+			message,
 		)
 
 		detailView := tview.NewTextView()


### PR DESCRIPTION
Since there is color scheme for events in general table view for each row, and since i am really "UI" person and my eye quickly begin to rely on that color scheme - i think this would be a pretty cool feature and help users like myself who really depends on color schemes.

![telegram-cloud-photo-size-2-5307613545678108172-y](https://github.com/user-attachments/assets/1baf40d7-c49c-49d9-a6c8-9c15d0988ca9)
![telegram-cloud-photo-size-2-5307613545678108173-y](https://github.com/user-attachments/assets/1c3b4f56-0652-499a-9b53-60d3d0a19959)
![telegram-cloud-photo-size-2-5307613545678108174-y](https://github.com/user-attachments/assets/601523cf-459e-4c64-8e4b-3d86e228d30f)

Basically a copypasta from `renderRow()`
